### PR TITLE
postinst: remove -p option for rmdir

### DIFF
--- a/debian/wazo-backup.postinst
+++ b/debian/wazo-backup.postinst
@@ -7,7 +7,7 @@ case "$1" in
 		# move files from xivo-backup
 		if [ -d /var/backups/xivo ] ; then
 			mv /var/backups/xivo/* /var/backups/wazo/
-			rmdir --ignore-fail-on-non-empty -p /var/backups/xivo
+			rmdir --ignore-fail-on-non-empty /var/backups/xivo
 		fi
         # End of move files from xivo-backup
 	;;


### PR DESCRIPTION
why: this option try to delete all directory in the path (i.e. /var,
/var/backups, /var/backups/xivo). But we only want to delete
/var/backups/xivo

On 'standard' install, it doesn't cause any issue, because /var/backups
is never empty, but on mounted volume, an error is raised (and not
caught by ignore-fail-on-non-empty)